### PR TITLE
Remove expired and dead APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,134 @@
 # TravelResources
+
 Are you building a travel app? Then you might find this repository useful.
 
 ### Flights
 
-| API | Description | Link |
-|---|---|---|
-| Skyscanner | Skyscanner for Business | [Go!](https://partners.skyscanner.net/) |
-| Sabre | Sabre® Dev Studio | [Go!](https://developer.sabre.com/docs/read/REST_APIs) |
-| Galileo | Travelport Galileo API | [Go!](https://developer.travelport.com/app/developer-network/classic-apis) |
-| Google Flights | QPX Express API | [Go!](https://developers.google.com/qpx-express/) |
-| Amadeus | Amadeus Global Distribution System | [Go!](http://api.dev.amadeus.net/api/index.htm) |
-| Rome2rio | Rome2rio API partner program | [Go!](https://www.rome2rio.com/documentation/) |
-| Tgels | Tgels Airfares REST api | [Go!](http://www.tgels.com/tapi/) |
-| Travelfusion | Travelfusion search and book api | [Go!](http://xmldocs.travelfusion.com/home/search-and-book-api) |
-| Ebookers | ebookers API | [Go!](https://www.ebookers.com/p/network-affiliate) |
-| Wego | Wego Flights API | [Go!](http://support.wan.travel/hc/en-us/articles/200191669) |
-| Allmyles | Allmyles Flights API | [Go!](http://docs.allmyles.apiary.io/#) |
+| API          | Description                        | Link                                                                       |
+| ------------ | ---------------------------------- | -------------------------------------------------------------------------- |
+| Skyscanner   | Skyscanner for Business            | [Go!](https://partners.skyscanner.net/)                                    |
+| Sabre        | Sabre® Dev Studio                  | [Go!](https://developer.sabre.com/docs/read/REST_APIs)                     |
+| Galileo      | Travelport Galileo API             | [Go!](https://developer.travelport.com/app/developer-network/classic-apis) |
+| Amadeus      | Amadeus Global Distribution System | [Go!](http://api.dev.amadeus.net/api/index.htm)                            |
+| Rome2rio     | Rome2rio API partner program       | [Go!](https://www.rome2rio.com/documentation/)                             |
+| Tgels        | Tgels Airfares REST api            | [Go!](http://www.tgels.com/tapi/)                                          |
+| Travelfusion | Travelfusion search and book api   | [Go!](http://xmldocs.travelfusion.com/home/search-and-book-api)            |
+| Ebookers     | ebookers API                       | [Go!](https://www.ebookers.com/p/network-affiliate)                        |
+| Wego         | Wego Flights API                   | [Go!](http://support.wan.travel/hc/en-us/articles/200191669)               |
+| Allmyles     | Allmyles Flights API               | [Go!](http://docs.allmyles.apiary.io/#)                                    |
 
 ### Flight data
 
-| API | Description | Link |
-|---|---|---|
+| API         | Description              | Link                                                          |
+| ----------- | ------------------------ | ------------------------------------------------------------- |
 | Flightstats | Flight data services api | [Go!](https://developer.flightstats.com/api-docs/airports/v1) |
 
 ### Airport services
 
-| API | Description | Link |
-|---|---|---|
+| API    | Description    | Link                                           |
+| ------ | -------------- | ---------------------------------------------- |
 | FlySFO | FlySFO.com API | [Go!](http://www.flysfo.com/api-documentation) |
 
 ### Hotels / Rentals
 
-| API | Description | Link |
-|---|---|---|
-| EAN | Expedia Affiliate Network | [Go!](http://developer.ean.com/) |
-| Hotwire | Hotwire Network | [Go!](http://developer.hotwire.com/) |
-| Lastminute | lastminute.com Partner Connect  | [Go!](http://connect.lastminute.com/Developer) |
-| TIXIK | TIXIK.com API | [Go!](http://www.tixik.com/info/api/) |
-| Tripadvisor | Tripadvisor content api | [Go!](https://developer-tripadvisor.com/content-api/) |
-| Homeaway | Rental property api | [Go!](https://www.homeaway.com/platform/developer-api)
-| Stay22 | Hotels close to events api | [Go!](https://www.stay22.com/embed)
-| Zumata | Multi-Source Hotel Booking API | [Go!](https://zumata.com/travel-solutions/hotel-api/)
-| Allmyles | Allmyles Hotels API | [Go!](http://docs.allmyles.apiary.io/#) |
+| API         | Description                    | Link                                                   |
+| ----------- | ------------------------------ | ------------------------------------------------------ |
+| EPS Rapid   | Expedia Rapid API              | [Go!](https://developer.expediapartnersolutions.com/)  |
+| Hotwire     | Hotwire Network                | [Go!](http://developer.hotwire.com/)                   |
+| Lastminute  | lastminute.com Partner Connect | [Go!](http://connect.lastminute.com/Developer)         |
+| TIXIK       | TIXIK.com API                  | [Go!](http://www.tixik.com/info/api/)                  |
+| Tripadvisor | Tripadvisor content api        | [Go!](https://developer-tripadvisor.com/content-api/)  |
+| Homeaway    | Rental property api            | [Go!](https://www.homeaway.com/platform/developer-api) |
+| Stay22      | Hotels close to events api     | [Go!](https://www.stay22.com/embed)                    |
+| Zumata      | Multi-Source Hotel Booking API | [Go!](https://zumata.com/travel-solutions/hotel-api/)  |
+| Allmyles    | Allmyles Hotels API            | [Go!](http://docs.allmyles.apiary.io/#)                |
 
 ### Car rentals
 
-| API | Description | Link |
-|---|---|---|
-| Travelpd | Car Booking Engine | [Go!](http://www.travelpd.com/car-booking-engine) |
+| API        | Description              | Link                                                                                |
+| ---------- | ------------------------ | ----------------------------------------------------------------------------------- |
+| Travelpd   | Car Booking Engine       | [Go!](http://www.travelpd.com/car-booking-engine)                                   |
 | Skyscanner | Skyscanner Car Hire Live | [Go!](http://business.skyscanner.net/portal/en-GB/Documentation/CarHireLivePricing) |
-| Cartrawler | Car Booking Engine | [Go!](http://www.cartrawler.com/Cartrawler_Ajax_Booking_Engine.pdf) |
-| Allmyles | Allmyles Flights API | [Go!](http://docs.allmyles.apiary.io/#) |
+| Cartrawler | Car Booking Engine       | [Go!](http://www.cartrawler.com/Cartrawler_Ajax_Booking_Engine.pdf)                 |
+| Allmyles   | Allmyles Flights API     | [Go!](http://docs.allmyles.apiary.io/#)                                             |
 
 ### Events
 
-| API | Description | Link |
-|---|---|---|
-| Active | Search for events, classes, campgrounds | [Go!](http://developer.active.com/) |
-| Gadventures | Adventure activities | [Go!](https://developers.gadventures.com/docs/index.html) |
+| API         | Description                             | Link                                                      |
+| ----------- | --------------------------------------- | --------------------------------------------------------- |
+| Active      | Search for events, classes, campgrounds | [Go!](http://developer.active.com/)                       |
+| Gadventures | Adventure activities                    | [Go!](https://developers.gadventures.com/docs/index.html) |
 
 ### Reviews
 
-| API | Description | Link |
-|---|---|---|
-| Tripadvisor | Tripadvisor content api | [Go!](https://developer-tripadvisor.com/content-api/) |
-| Citygridmedia | Customer reviews api | [Go!](http://docs.citygridmedia.com/display/citygridv2/Reviews+API) |
-| Olery | Olery Review Data API | [Go!](http://www.olery.com/api/) |
+| API           | Description             | Link                                                                |
+| ------------- | ----------------------- | ------------------------------------------------------------------- |
+| Tripadvisor   | Tripadvisor content api | [Go!](https://developer-tripadvisor.com/content-api/)               |
+| Citygridmedia | Customer reviews api    | [Go!](http://docs.citygridmedia.com/display/citygridv2/Reviews+API) |
+| Olery         | Olery Review Data API   | [Go!](http://www.olery.com/api/)                                    |
 
 ### Travel Planning
 
-| API | Description | Link |
-|---|---|---|
+| API    | Description            | Link                                    |
+| ------ | ---------------------- | --------------------------------------- |
 | TripIt | Travel information api | [Go!](https://www.tripit.com/developer) |
-| Minube | Minube search API | [Go!](http://www.minube.com/api) |
+| Minube | Minube search API      | [Go!](http://www.minube.com/api)        |
 
 ### Guides
 
-| API | Description | Link |
-|---|---|---|
-| Getyourguide |  City guides api | [Go!](https://api.getyourguide.com/) |
+| API          | Description     | Link                                 |
+| ------------ | --------------- | ------------------------------------ |
+| Getyourguide | City guides api | [Go!](https://api.getyourguide.com/) |
 
 ### Currencies
 
-| API | Description | Link |
-|---|---|---|
-| Skyscanner | Skyscanner Currencies Service | [Go!](http://business.skyscanner.net/portal/en-GB/Documentation/Currencies) |
-| Fixer.io | JSON API for foreign exchange rates | [Go!](http://fixer.io/) |
+| API        | Description                         | Link                                                                        |
+| ---------- | ----------------------------------- | --------------------------------------------------------------------------- |
+| Skyscanner | Skyscanner Currencies Service       | [Go!](http://business.skyscanner.net/portal/en-GB/Documentation/Currencies) |
+| Fixer.io   | JSON API for foreign exchange rates | [Go!](http://fixer.io/)                                                     |
 
 ### Map services
 
-| API | Description | Link |
-|---|---|---|
-| Google | Google maps services api | [Go!](https://developers.google.com/maps/) |
-| Microsoft | Bing maps API | [Go!](https://www.microsoft.com/maps/choose-your-bing-maps-API.aspx) |
-| Mapbox | Mapbox web services | [Go!](https://www.mapbox.com/api-documentation/) |
-| Here | Interactive maps | [Go!](https://developer.here.com/develop/javascript-api) |
-| Viamichelin | Maps, routing and geocoding | [Go!](http://dev.viamichelin.com/) |
-| Factual | Location data | [Go!](https://www.factual.com/solutions/developers) |
+| API         | Description                 | Link                                                                 |
+| ----------- | --------------------------- | -------------------------------------------------------------------- |
+| Google      | Google maps services api    | [Go!](https://developers.google.com/maps/)                           |
+| Microsoft   | Bing maps API               | [Go!](https://www.microsoft.com/maps/choose-your-bing-maps-API.aspx) |
+| Mapbox      | Mapbox web services         | [Go!](https://www.mapbox.com/api-documentation/)                     |
+| Here        | Interactive maps            | [Go!](https://developer.here.com/develop/javascript-api)             |
+| Viamichelin | Maps, routing and geocoding | [Go!](http://dev.viamichelin.com/)                                   |
+| Factual     | Location data               | [Go!](https://www.factual.com/solutions/developers)                  |
 
 ### Free stock photos
 
-| URL | Description | Link |
-|---|---|---|
-| Pixabay  | Free images and videos | [Go!](https://pixabay.com/) |
+| URL          | Description               | Link                                           |
+| ------------ | ------------------------- | ---------------------------------------------- |
+| Pixabay      | Free images and videos    | [Go!](https://pixabay.com/)                    |
 | Image Source | Royalty Free Stock Photos | [Go!](http://www.imagesource.com/royalty-free) |
-| Picjumbo  | Free stock photos | [Go!](https://www.picjumbo.com) |
-| Unsplash  | Free stock photos | [Go!](https://unsplash.com/) |
-| Flickr  | Photos service | [Go!](https://www.flickr.com/services/api/) |
-| Pexels  | Free stock photos | [Go!](https://www.pexels.com/) |
+| Picjumbo     | Free stock photos         | [Go!](https://www.picjumbo.com)                |
+| Unsplash     | Free stock photos         | [Go!](https://unsplash.com/)                   |
+| Flickr       | Photos service            | [Go!](https://www.flickr.com/services/api/)    |
+| Pexels       | Free stock photos         | [Go!](https://www.pexels.com/)                 |
 
 ### Geolocation
 
-| API | Description | Link |
-|---|---|---|
+| API    | Description        | Link                           |
+| ------ | ------------------ | ------------------------------ |
 | Ip-api | IP Geolocation API | [Go!](http://ip-api.com/docs/) |
 
 ### Other services
 
-| API | Description | Link |
-|---|---|---|
-| Adventurelink | Trips finder api | [Go!](http://api.adventurelink.com/) |
-| Bestparking | Airport parking api | [Go!](http://www.bestparking.com/developers/) |
-| OAG | Airline schedules  | [Go!](http://www.oag.com/schedules/schedulesondemand) |
-| Flyontime | Flight times  | [Go!](http://www.flyontime.us/developers) |
-| Inknowledge | Taxi Fare REST Service  | [Go!](http://inknowledge.co.uk/Products/TaxiFareWebServices.aspx) |
-| Uber | Uber api  | [Go!](https://developer.uber.com/) |
-| Timezonedb | Time Zones api  | [Go!](https://timezonedb.com/api) |
-| WorldMate | WorldMate Email Parsing API  | [Go!](https://developers.worldmate.com/) |
-| Webcams.travel API | Webcams.travel API  | [Go!](http://www.webcams.travel/developers/) |
-| Sunset and sunrise API | Sunset and sunrise times API  | [Go!](http://sunrise-sunset.org/api) |
+| API                    | Description                  | Link                                                              |
+| ---------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| Adventurelink          | Trips finder api             | [Go!](http://api.adventurelink.com/)                              |
+| Bestparking            | Airport parking api          | [Go!](http://www.bestparking.com/developers/)                     |
+| OAG                    | Airline schedules            | [Go!](http://www.oag.com/schedules/schedulesondemand)             |
+| Flyontime              | Flight times                 | [Go!](http://www.flyontime.us/developers)                         |
+| Inknowledge            | Taxi Fare REST Service       | [Go!](http://inknowledge.co.uk/Products/TaxiFareWebServices.aspx) |
+| Uber                   | Uber api                     | [Go!](https://developer.uber.com/)                                |
+| Timezonedb             | Time Zones api               | [Go!](https://timezonedb.com/api)                                 |
+| WorldMate              | WorldMate Email Parsing API  | [Go!](https://developers.worldmate.com/)                          |
+| Webcams.travel API     | Webcams.travel API           | [Go!](http://www.webcams.travel/developers/)                      |
+| Sunset and sunrise API | Sunset and sunrise times API | [Go!](http://sunrise-sunset.org/api)                              |
 
 ## License
 


### PR DESCRIPTION
Not quite sure why my environment has attempted to add the whitespace in order to align things...prettier maybe? The markdown was formatted like that after I opened the file the first time. Only maybe 6 links were removed or modified myself.

Related to #3 