### PR TITLE
Correct link to Galileo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Are you building a travel app? Then you might find this repository useful.
 | Skyscanner | Skyscanner for Business | [Go!](https://skyscanner.github.io/slate/#api-documentation) |
 | Sabre | Sabre® Dev Studio | [Go!](https://developer.sabre.com/docs/read/REST_APIs) |
 | Galileo | Travelopro Galileo GDS API | [Go!](https://www.travelopro.com/galileo-gds-api-integration.php) |
-| Amadeus | Amadeus Global Distribution System | [Go!](http://api.dev.amadeus.net/api/index.htm) |
+| Amadeus | Amadeus Travel APIs | [Go!](https://developers.amadeus.com) |
 | Rome2rio | Rome2rio API partner program | [Go!](https://www.rome2rio.com/documentation/) |
 | Travelfusion | Travelfusion search and book api | [Go!](http://xmldocs.travelfusion.com/home/search-and-book-api) |
 | Ebookers | ebookers API | [Go!](https://www.ebookers.com/p/network-affiliate) |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Are you building a travel app? Then you might find this repository useful.
 |---|---|---|
 | Skyscanner | Skyscanner for Business | [Go!](https://skyscanner.github.io/slate/#api-documentation) |
 | Sabre | Sabre® Dev Studio | [Go!](https://developer.sabre.com/docs/read/REST_APIs) |
-| Galileo | Travelport Galileo API | [Go!](https://developer.travelport.com/app/developer-network/classic-apis) |
+| Galileo | Travelopro Galileo GDS API | [Go!](https://www.travelopro.com/galileo-gds-api-integration.php) |
 | Amadeus | Amadeus Global Distribution System | [Go!](http://api.dev.amadeus.net/api/index.htm) |
 | Rome2rio | Rome2rio API partner program | [Go!](https://www.rome2rio.com/documentation/) |
 | Travelfusion | Travelfusion search and book api | [Go!](http://xmldocs.travelfusion.com/home/search-and-book-api) |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Are you building a travel app? Then you might find this repository useful.
 | Ebookers | ebookers API | [Go!](https://www.ebookers.com/p/network-affiliate) |
 | Wego | Wego Flights API | [Go!](http://support.wan.travel/hc/en-us/articles/200191669) |
 | Allmyles | Allmyles Flights API | [Go!](http://docs.allmyles.apiary.io/#) |
+| Trawex | Trawex Universal Flight API | [Go!](https://www.trawex.com/flight-api.php) |
 
 ### Flight data
 


### PR DESCRIPTION
Remove old and add new link in Galileo. New link-(https://www.travelopro.com/galileo-gds-api-integration.php)